### PR TITLE
[PE-2468] [PE-2498] Added OidC session RP logout endpoint

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -27,6 +27,7 @@ module Doorkeeper
           authorization_endpoint: oauth_authorization_url,
           token_endpoint: oauth_token_url,
           userinfo_endpoint: oauth_userinfo_url,
+          end_session_endpoint: oauth_rp_logout_url,
           jwks_uri: oauth_discovery_keys_url,
 
           scopes_supported: doorkeeper.scopes,

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -89,7 +89,7 @@ module Doorkeeper
 
         {
           keys: [
-            signing_key.slice(:kty, :kid, :e, :n).merge(
+            signing_key.slice(:kty, :kid, :e, :n, :x, :y, :crv).merge(
               use: 'sig',
               alg: Doorkeeper::OpenidConnect.signing_algorithm
             )

--- a/app/controllers/doorkeeper/openid_connect/rp_logout_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/rp_logout_controller.rb
@@ -1,0 +1,57 @@
+module Doorkeeper
+  module OpenidConnect
+    class RpLogoutController < ::Doorkeeper::ApplicationController
+      skip_before_action :verify_authenticity_token
+
+      def show
+        ## Query Parameters
+        # id_token_hint
+        #   RECOMMENDED. Previously issued ID Token passed to the logout endpoint as a hint 
+        #   about the End-User's current authenticated session with the Client. This is used 
+        #   as an indication of the identity of the End-User that the RP is requesting be 
+        #   logged out by the OP. The OP need not be listed as an audience of the ID Token when
+        #   it is used as an id_token_hint value.
+        # post_logout_redirect_uri
+        #   OPTIONAL. URL to which the RP is requesting that the End-User's User Agent be 
+        #   redirected after a logout has been performed. The value MUST have been previously
+        #   registered with the OP, either using the post_logout_redirect_uris Registration
+        #   parameter or via another mechanism. If supplied, the OP SHOULD honor this request following the logout.
+        # state
+        #   OPTIONAL. Opaque value used by the RP to maintain state between the logout request and the callback to the endpoint specified by the post_logout_redirect_uri query parameter. If included in the logout request, the OP passes this value back to the RP using the state query parameter when redirecting the User Agent back to the RP.
+
+        # client = doorkeeper_token.application
+        instance_exec current_user, &Doorkeeper::OpenidConnect.configuration.logout_resource_owner
+
+        if params[:post_logout_redirect_uri].present?
+          begin
+            redirect_uri = URI.parse(params[:post_logout_redirect_uri])
+
+            # TODO: Handle state parameter
+            # TODO: Handle id_token_hint (if needed to lookup session?)
+
+            # HACK: quick check to make sure that the domain is a venuenext.net domain.
+            # TODO: this needs to be a property on the Doorkeeper::Application (allowed redirect_uris)
+            # it needs to work similarly to how redirect_uri validation works in oauth2.
+            if redirect_uri.host.ends_with?('venuenext.net')
+              redirect_to redirect_uri.to_s
+              return
+            else
+              render json: { errors: { post_logout_redirect_uri: ["Unauthorized Post Logout Redirect URI."] } }
+              return
+            end
+
+          rescue URI::InvalidURIError => e
+            render json: { errors: { post_logout_redirect_uri: ["Invalid URI"] } }
+            return
+          end
+        end
+
+        redirect_to "/"
+
+        # resource_owner = Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(doorkeeper_token)
+        # user_info = Doorkeeper::OpenidConnect::UserInfo.new(resource_owner, doorkeeper_token.scopes)
+        # render json: user_info, status: :ok
+      end
+    end
+  end
+end

--- a/app/controllers/doorkeeper/openid_connect/rp_logout_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/rp_logout_controller.rb
@@ -50,10 +50,6 @@ module Doorkeeper
         end
 
         redirect_to "/"
-
-        # resource_owner = Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(doorkeeper_token)
-        # user_info = Doorkeeper::OpenidConnect::UserInfo.new(resource_owner, doorkeeper_token.scopes)
-        # render json: user_info, status: :ok
       end
     end
   end

--- a/app/controllers/doorkeeper/openid_connect/rp_logout_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/rp_logout_controller.rb
@@ -18,6 +18,9 @@ module Doorkeeper
         #   parameter or via another mechanism. If supplied, the OP SHOULD honor this request following the logout.
         # state
         #   OPTIONAL. Opaque value used by the RP to maintain state between the logout request and the callback to the endpoint specified by the post_logout_redirect_uri query parameter. If included in the logout request, the OP passes this value back to the RP using the state query parameter when redirecting the User Agent back to the RP.
+        #
+        ## Documentation for the Spec
+        # https://openid.net/specs/openid-connect-session-1_0.html#RPLogout
 
         # client = doorkeeper_token.application
         instance_exec current_user, &Doorkeeper::OpenidConnect.configuration.logout_resource_owner

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,3 +20,4 @@ en:
           auth_time_from_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.auth_time_from_resource_owner missing configuration.'
           reauthenticate_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.reauthenticate_resource_owner missing configuration.'
           subject_not_configured: 'ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.'
+          logout_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.logout_resource_owner missing configuration.'

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -107,6 +107,10 @@ module Doorkeeper
         fail Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.reauthenticate_resource_owner_not_configured')
       }
 
+      option :logout_resource_owner, default: lambda { |*_|
+        fail Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.logout_resource_owner_not_configured')
+      }
+
       option :subject, default: lambda { |*_|
         fail Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.subject_not_configured')
       }

--- a/lib/doorkeeper/openid_connect/rails/routes.rb
+++ b/lib/doorkeeper/openid_connect/rails/routes.rb
@@ -26,6 +26,7 @@ module Doorkeeper
           @mapping = Mapper.new.map(&@block)
           routes.scope options[:scope] || 'oauth', as: 'oauth' do
             map_route(:userinfo, :userinfo_routes)
+            map_route(:rp_logout, :rp_logout_routes)
             map_route(:discovery, :discovery_routes)
           end
 
@@ -49,6 +50,10 @@ module Doorkeeper
         def userinfo_routes
           routes.get :show, path: 'userinfo', as: ''
           routes.post :show, path: 'userinfo', as: nil
+        end
+
+        def rp_logout_routes
+          routes.get :show, path: 'rp_logout', as: ''
         end
 
         def discovery_routes

--- a/lib/doorkeeper/openid_connect/rails/routes/mapping.rb
+++ b/lib/doorkeeper/openid_connect/rails/routes/mapping.rb
@@ -8,12 +8,14 @@ module Doorkeeper
           def initialize
             @controllers = {
               userinfo: 'doorkeeper/openid_connect/userinfo',
-              discovery: 'doorkeeper/openid_connect/discovery'
+              discovery: 'doorkeeper/openid_connect/discovery',
+              rp_logout: 'doorkeeper/openid_connect/rp_logout',
             }
 
             @as = {
               userinfo: :userinfo,
-              discovery: :discovery
+              discovery: :discovery,
+              rp_logout: :rp_logout,
             }
 
             @skips = []

--- a/lib/doorkeeper/openid_connect/version.rb
+++ b/lib/doorkeeper/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
   module OpenidConnect
-    VERSION = '1.1.2'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/lib/doorkeeper/openid_connect/version.rb
+++ b/lib/doorkeeper/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
   module OpenidConnect
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.1.2+vn.1'.freeze
   end
 end


### PR DESCRIPTION
**PE-2498**  
Added missing keys from oidc library to the discovery#keys response so that the EC public key values (:crv, :x and :y) would be returned in that response.

**PE-2468**  
Added RP logout endpoint, with hard-coded url validation to venuenext.net domains. There is some more work that could be done to better follow the [Session Spec for RP Logouts](https://openid.net/specs/openid-connect-session-1_0.html#RPLogout).