### PR TITLE
ABC-404 Allow localhost post logout redirect uri

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/rp_logout_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/rp_logout_controller.rb
@@ -6,20 +6,20 @@ module Doorkeeper
       def show
         ## Query Parameters
         # id_token_hint (TODO: implement id_token_hint)
-        #   RECOMMENDED. Previously issued ID Token passed to the logout endpoint as a hint 
-        #   about the End-User's current authenticated session with the Client. This is used 
-        #   as an indication of the identity of the End-User that the RP is requesting be 
+        #   RECOMMENDED. Previously issued ID Token passed to the logout endpoint as a hint
+        #   about the End-User's current authenticated session with the Client. This is used
+        #   as an indication of the identity of the End-User that the RP is requesting be
         #   logged out by the OP. The OP need not be listed as an audience of the ID Token when
         #   it is used as an id_token_hint value.
         # post_logout_redirect_uri
-        #   OPTIONAL. URL to which the RP is requesting that the End-User's User Agent be 
+        #   OPTIONAL. URL to which the RP is requesting that the End-User's User Agent be
         #   redirected after a logout has been performed. The value MUST have been previously
         #   registered with the OP, either using the post_logout_redirect_uris Registration
         #   parameter or via another mechanism. If supplied, the OP SHOULD honor this request
         #   following the logout.
         # state
-        #   OPTIONAL. Opaque value used by the RP to maintain state between the logout request 
-        #   and the callback to the endpoint specified by the post_logout_redirect_uri query 
+        #   OPTIONAL. Opaque value used by the RP to maintain state between the logout request
+        #   and the callback to the endpoint specified by the post_logout_redirect_uri query
         #   parameter. If included in the logout request, the OP passes this value back to the
         #   RP using the state query parameter when redirecting the User Agent back to the RP.
         #
@@ -39,7 +39,7 @@ module Doorkeeper
             # HACK: quick check to make sure that the domain is a venuenext.net domain.
             # TODO: this needs to be a property on the Doorkeeper::Application (allowed redirect_uris)
             # it needs to work similarly to how redirect_uri validation works in oauth2.
-            if redirect_uri.host.ends_with?('venuenext.net')
+            if redirect_uri.host.ends_with?('venuenext.net') || redirect_uri.host.ends_with?('localhost')
               # Handle state parameter
               if params[:state].present?
                 redirect_uri = uri_query_merge(redirect_uri, state: params[:state])

--- a/spec/controllers/rp_logout_controller_spec.rb
+++ b/spec/controllers/rp_logout_controller_spec.rb
@@ -14,11 +14,18 @@ describe Doorkeeper::OpenidConnect::RpLogoutController, type: :controller do
         end
       end
 
-      it 'redirects to the specified post_logout_redirect_uri' do 
+      it 'redirects to the specified post_logout_redirect_uri' do
         get :show, post_logout_redirect_uri: 'https://test.venuenext.net'
 
         expect(response.status).to eq 302
         expect(response).to redirect_to('https://test.venuenext.net')
+      end
+
+      it 'redirects to the specified localhost post_logout_redirect_uri' do
+        get :show, post_logout_redirect_uri: 'https://localhost:3000'
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to('https://localhost:3000')
       end
 
       it 'redirects to the specified post_logout_redirect_uri with the state' do
@@ -36,7 +43,7 @@ describe Doorkeeper::OpenidConnect::RpLogoutController, type: :controller do
       end
 
       it 'merges the query parameters with the state in an encoded post_logout_redirect_uri' do
-        get :show, 
+        get :show,
           post_logout_redirect_uri: 'https://test.venuenext.net/path/?state=bob&param2=8912',
           state: 'test999'
 
@@ -67,7 +74,7 @@ describe Doorkeeper::OpenidConnect::RpLogoutController, type: :controller do
         end
       end
 
-      it 'returns an error for non venuenext.net domains' do 
+      it 'returns an error for non venuenext.net domains' do
         get :show, post_logout_redirect_uri: 'https://test.otherdomain.net'
 
         expect(response.status).to eq 400


### PR DESCRIPTION
## Description
This will allow the `post_logout_redirect_uri` to function correctly in VN development environment.
## JIRA Ticket
https://venuenext.atlassian.net/browse/ABC-404
## Related PRs
https://github.com/venuenext/canopy/pull/2685